### PR TITLE
7 fix card components

### DIFF
--- a/client/src/components/Card.vue
+++ b/client/src/components/Card.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-  import Tag from './Tag.vue';
   import {
     ArrowCircleRightIcon,
     ChevronRightIcon
   } from '@heroicons/vue/solid';
+  import Tag from './Tag.vue';
   export default {
     props: [
       'head',
@@ -18,18 +18,18 @@
         else {
           body.setAttribute('class', 'h-8 overflow-auto py-1');
         }
-        if (icon.getAttribute('class') == 'transition ease origin-center') {
-          icon.setAttribute('class', 'transition ease origin-center rotate-90');
+        if (icon.getAttribute('class') == 'ease h-5 origin-center transition w-5') {
+          icon.setAttribute('class', 'ease h-5 origin-center rotate-90 transition w-5');
         }
         else {
-          icon.setAttribute('class', 'transition ease origin-center');
+          icon.setAttribute('class', 'ease h-5 origin-center transition w-5');
         }
       },
       action(event: any) {
         let body: any, icon: any;
         if (event.target.tagName == 'DIV') {
           body = event.target.nextSibling;
-          icon = event.target.childNodes['1'].childNodes['1'];
+          icon = event.target.querySelector('#heroicon');
         }
         if (this.$route.name == 'Home') {
           // TODO: Router link to '/'
@@ -61,10 +61,14 @@
           />
         </div>
         <template v-if="this.$route.name == 'Home'">
-          <ArrowCircleRightIcon class="h-5 w-5" />
+          <div class="h-5 w-5" id="heroicon">
+            <ArrowCircleRightIcon/>
+          </div>
         </template>
         <template v-else-if="this.$route.name != 'Contact'">
-          <ChevronRightIcon class="ease h-5 origin-center transition w-5"/>
+          <div class="ease h-5 origin-center transition w-5" id="heroicon">
+            <ChevronRightIcon/>
+          </div>
         </template>
       </div>
     </div>

--- a/client/src/components/Card.vue
+++ b/client/src/components/Card.vue
@@ -12,11 +12,11 @@
     ],
     methods: {
       flip(body: any, icon: any) {
-        if (body.getAttribute('class') == 'h-8 overflow-auto py-1') {
-          body.setAttribute('class', 'h-full overflow-auto py-1');
+        if (body.getAttribute('class') == 'font-serif h-8 overflow-auto scroll-smooth py-1') {
+          body.setAttribute('class', 'font-serif h-full overflow-auto scroll-smooth py-1');
         }
         else {
-          body.setAttribute('class', 'h-8 overflow-auto py-1');
+          body.setAttribute('class', 'font-serif h-8 overflow-auto scroll-smooth py-1');
         }
         if (icon.getAttribute('class') == 'ease h-5 origin-center transition w-5') {
           icon.setAttribute('class', 'ease h-5 origin-center rotate-90 transition w-5');
@@ -26,13 +26,37 @@
         }
       },
       action(event: any) {
-        let body: any, icon: any;
-        if (event.target.tagName == 'DIV') {
-          body = event.target.nextSibling;
-          icon = event.target.querySelector('#heroicon');
+        // TODO: Define Tag routing in its own component
+        //  so that it can be called here
+        let
+          body: any,
+          elem: any = event.target,
+          icon: any;
+        const getElemId: any = (elem: any) => {
+            return elem.getAttribute('id');
         }
-        if (this.$route.name == 'Home') {
+        let elemId: any = getElemId(elem);
+        if (elemId != 'head') {
+          console.log("not head");
+          while (elemId != 'head') {
+            console.log("hit " + elemId);
+            if (elemId === 'tag') {
+              // TODO: Define Tag routing in its own component
+              console.log('TODO: Define Tag routing in its own component');
+              return;
+            }
+            elem = elem.parentNode;
+            elemId = getElemId(elem);
+          }
+        }
+        console.log("hit " + elemId);
+        body = elem.nextSibling;
+        console.log("body: " + body.getAttribute('id'));
+        icon = elem.querySelector('#chevron-right-icon');
+        console.log("icon: " + icon.getAttribute('id'));
+        if (this.$route.name === 'Home') {
           // TODO: Router link to '/'
+          console.log("/ TODO: Router link to '/'");
         }
         else if (this.$route.name != 'Contact') {
           this.flip(body, icon);
@@ -48,30 +72,47 @@
 </script>
 
 <template>
-  <div class="bg-amber-50 border-l-8 border-amber-800 divide-amber-200 divide-y drop-shadow-md my-2 px-4 py-2 rounded-lg">
-    <div @click="action" class="cursor-pointer flex justify-between">
-      <h4 class="font-bold text-amber-800">
+  <div
+    class="bg-amber-50 border-l-8 border-amber-800 divide-amber-200 divide-y drop-shadow-md my-2 px-4 py-2 rounded-lg"
+    id="card">
+    <div @click="action"
+      class="cursor-pointer flex justify-between"
+      id="head">
+      <h4
+        class="font-bold select-none text-amber-800"
+        id="title">
         {{ head }}
       </h4>
-      <div class="flex gap-3 justify-between">
-        <div class="flex gap-2 justify-between text-sm">
-          <Tag v-for="tag in tags"
+      <div
+        class="flex gap-3 justify-between"
+        id="info">
+        <div
+          class="flex gap-2 justify-between text-sm"
+          id="tags">
+          <Tag id="tag" v-for="tag in tags"
             :key="tag"
-            :keyword="tag"
-          />
+            :keyword="tag"/>
         </div>
         <template v-if="this.$route.name == 'Home'">
-          <div class="h-5 w-5" id="heroicon">
+          <div
+          class="h-5 w-5"
+          id="arrow-circle-right-icon">
             <ArrowCircleRightIcon/>
           </div>
         </template>
         <template v-else-if="this.$route.name != 'Contact'">
-          <div class="ease h-5 origin-center transition w-5" id="heroicon">
+          <div
+          class="ease h-5 origin-center transition w-5"
+          id="chevron-right-icon">
             <ChevronRightIcon/>
           </div>
         </template>
       </div>
     </div>
-    <div class="font-serif h-8 overflow-auto py-1" v-html="body"></div>
+    <div
+      class="font-serif h-8 overflow-auto py-1 scroll-smooth"
+      id="body"
+      v-html="body">
+    </div>
   </div>
 </template>

--- a/client/src/components/Tag.vue
+++ b/client/src/components/Tag.vue
@@ -6,7 +6,7 @@
 </script>
 
 <template>
-  <div class="bg-amber-200 flex font-mono pt-0.5 px-2 rounded-lg">
+  <div class="bg-amber-200 flex font-mono pt-0.5 px-2 rounded-lg" id="tag">
     <svg xmlns="http://www.w3.org/2000/svg" class="h-5 fill-amber-600 w-5" viewBox="0 0 20 20">
       <path fill-rule="evenodd" d="M9.243 3.03a1 1 0 01.727 1.213L9.53 6h2.94l.56-2.243a1 1 0 111.94.486L14.53 6H17a1 1 0 110 2h-2.97l-1 4H15a1 1 0 110 2h-2.47l-.56 2.242a1 1 0 11-1.94-.485L10.47 14H7.53l-.56 2.242a1 1 0 11-1.94-.485L5.47 14H3a1 1 0 110-2h2.97l1-4H5a1 1 0 110-2h2.47l.56-2.243a1 1 0 011.213-.727zM9.03 8l-1 4h2.938l1-4H9.031z" clip-rule="evenodd" />
     </svg>

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -17,7 +17,7 @@ app.use(router);
 
 // Prefetches
 // Briefs
-axios.get(
+await axios.get(
   `${HOST}:${PORT}/briefs/`
 ).then(response => {
   app.provide('briefs', response.data);
@@ -26,7 +26,7 @@ axios.get(
 });
 
 // Projects
-axios.get(
+await axios.get(
   `${HOST}:${PORT}/projects/`
 ).then(response => {
   app.provide('projects', response.data);
@@ -35,7 +35,7 @@ axios.get(
 });
 
 // Tags
-axios.get(
+await axios.get(
   `${HOST}:${PORT}/tags/`
 ).then(response => {
   app.provide('tags', response.data);


### PR DESCRIPTION
This was a surprisingly easy fix! I just had to inspect the DOM tree and figure out which elements were actually being selected. **Using `inspect` to watch the DOM change as I clicked on the button handler was very useful.**

It turns out that I was actually selecting the `svg` tag, and that I needed to wrap it in its own `div`. I moved to using `querySelector` which I should have been using in the first place. Not only that, but the CSS being re-applied to the selected element was a mismatch with its initial CSS, which was the source of those weird bugs. Mystery solved.

Some other important changes here. I wanted the entire header _except_ for the tags to call the `flip` event. I succeeded, but the logic for the tags is yet to be done, and that's not a concern right now. In doing this, I found a way to refactor the action logic and reduce it down to a quarter of its size, making the file more concise than before. 

This closes issue #7 `Fix card components`. On this branch I also fixed access to all routes, which was due to not placing `await`s in front of my `axios` calls. This closes issue #5 `Fix access to routes`.